### PR TITLE
iframeから親のmeta要素を削除するよう修正 

### DIFF
--- a/cbp-src/html/twitterstamp.html
+++ b/cbp-src/html/twitterstamp.html
@@ -36,6 +36,13 @@
 			);
 		});
 	});
+	$(function(){
+		window.parent.$("meta[name='twitter:card']").remove();
+		window.parent.$("meta[name='twitter:site']").remove();
+		window.parent.$("meta[name='twitter:title']").remove();
+		window.parent.$("meta[name='twitter:description']").remove();
+		window.parent.$("meta[name='twitter:image']").remove()
+	});
 	</script>
 </head>
 <body>


### PR DESCRIPTION
![97830502](https://cloud.githubusercontent.com/assets/4990822/13064293/e5a8d41a-d494-11e5-89be-18d951af932e.jpg)

## 概要

`cbp-src/html/twitterstamp.html`でのみ、親の`<meta name="twitter:〜">`を削除する様にしました。多分動くと思います。

jqueryはよくわかんないので、削除する要素をベタ書きしてます。配列で取得していい感じに削除できるようなら、マージ後修正お願いします…


ref: #1 